### PR TITLE
perf: remove disconnect option

### DIFF
--- a/lib/filteredStream/disconnectFilteredStream.js
+++ b/lib/filteredStream/disconnectFilteredStream.js
@@ -1,7 +1,0 @@
-const disconnectFilteredStream = () => {
-  console.log(`Disconnecting filtered stream...`)
-  filteredStream.disconnect()
-  console.log(`Disconnected filtered stream.`)
-}
-
-export default disconnectFilteredStream

--- a/lib/filteredStream/filteredStreamMenu.js
+++ b/lib/filteredStream/filteredStreamMenu.js
@@ -1,6 +1,5 @@
 import inquirer from "inquirer"
 import startFilteredStream from "./startFilteredStream.js"
-import disconnectFilteredStream from "./disconnectFilteredStream.js"
 import addRule from "./addRule.js"
 import deleteRule from "./deleteRule.js"
 import getRules from "./getRules.js"
@@ -12,11 +11,10 @@ const filteredStreamMenu = () => {
       name: "filteredStream",
       message: "Filtered stream:",
       choices: [
+        "Get rule(s)",
         "Start stream",
-        "Disconnect stream",
         "Add rule",
         "Delete rule",
-        "Get rules",
         "Exit",
       ],
     },
@@ -27,9 +25,6 @@ const filteredStreamMenu = () => {
       switch (answer.filteredStream) {
         case "Start stream":
           startFilteredStream()
-          break
-        case "Disconnect stream":
-          disconnectFilteredStream()
           break
         case "Add rule":
           addRule()


### PR DESCRIPTION
Won't fix--the filter stream is designed to be long running, and not disconnect frequently. A much better way to go, is to use the Rules API to add and remove the rules used to filter, not the connection. 